### PR TITLE
Added docker files for the REST Api

### DIFF
--- a/stream022/Dockerfile-node
+++ b/stream022/Dockerfile-node
@@ -1,0 +1,5 @@
+FROM node:8.16.0-alpine
+COPY . /usr/src/rest
+WORKDIR /usr/src/rest
+RUN npm install
+CMD node api.js

--- a/stream022/docker-compose.yml
+++ b/stream022/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    volumes:
+      - ./schema.sql:/docker-entrypoint-initdb.d/dump.sql
+    restart: always
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: root
+#  node-server:
+#    build:
+#      context: .
+#      dockerfile: Dockerfile-node
+#    ports:
+#      - 9000:9000
+#    depends_on:
+#      - mysql

--- a/stream022/models.js
+++ b/stream022/models.js
@@ -3,7 +3,7 @@ const path = require('path');
 const Sequelize = require('sequelize');
 const basename = path.basename(module.filename);
 const sequelize = new Sequelize('test', 'root', 'root', { // db name, username, password
-    host: '127.0.0.1',
+    host: '127.0.0.1', // when dockerized, write 'mysql' as the host
     dialect: 'mysql',
     logging: false,
     timezone: '+00:00',

--- a/stream022/notes.yml
+++ b/stream022/notes.yml
@@ -45,3 +45,7 @@ get this code working:
     - load data from schema.sql into your database
     - update models.js line 5 with your db config
     - run node api.js
+  dockerized way:
+    - update models.js line 6 with 'mysql'
+    - optionally uncomment the node server section in the docker-compose.yml file to start a node server, too
+    - run 'docker-compose up' to start the container


### PR DESCRIPTION
Added a dockerized way to start the MySQL 5.7 database initialized with the schema.sql script. 
Optionally a node server with the files is also included if someone wants to try out the rest api without running it locally.