### PR TITLE
Create ht_destroy routine to properly free up memory. Added call to m…

### DIFF
--- a/077/hashtable.c
+++ b/077/hashtable.c
@@ -202,6 +202,44 @@ void ht_dump(ht_t *hashtable) {
     }
 }
 
+void ht_destroy(ht_t *hashtable)
+{
+    if(!hashtable) return;
+
+    size_t i = 0;
+    if(hashtable->entries)
+    {
+        //Free all entries
+        while(i < TABLE_SIZE)
+        {
+            if(hashtable->entries[i])
+            {
+                if(hashtable->entries[i]->key)
+                {
+                    free(hashtable->entries[i]->key);
+                    hashtable->entries[i]->key = NULL;
+                }
+                if(hashtable->entries[i]->value)
+                {
+                    free(hashtable->entries[i]->value);
+                    hashtable->entries[i]->value = NULL;
+                }
+                free(hashtable->entries[i]);
+                hashtable->entries[i] = NULL;
+            }
+            i++;
+        }
+        //Free the entry list pointer
+        free(hashtable->entries);
+        hashtable->entries = NULL;
+    }
+
+    //Free the hashtable pointer
+    free(hashtable);
+    hashtable = NULL;
+    return;
+}
+
 int main(int argc, char **argv) {
     ht_t *ht = ht_create();
 
@@ -214,6 +252,7 @@ int main(int argc, char **argv) {
     ht_set(ht, "name7", "kalix");
 
     ht_dump(ht);
+    ht_destroy(ht);
 
     return 0;
 }


### PR DESCRIPTION
Hi Engineer Man. I really enjoyed this tutorial and learned a lot. Unfortunately, there were 23 memory leaks in the code! I wrote a new `ht_destroy` function and added it to the end of `main` to fix these.I verified with Valgrind (see screenshot which has before and after) that these leaks are now gone.
![hashtable_leaks](https://user-images.githubusercontent.com/57550024/70383144-c77faa00-191d-11ea-9eab-22567e8e29ba.png) . It's always a good practice to FREE all memory used because otherwise the program could crash or have a vulnerability.

Sincerely,
itsallmathematics