### PR TITLE
port collision fix suggestion

### DIFF
--- a/141/client.py
+++ b/141/client.py
@@ -40,15 +40,15 @@ print('ready to exchange messages\n')
 
 # listen for
 # equiv: nc -u -l 50001
-def listen():
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(('0.0.0.0', sport))
+def listen(sock):
+    # sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    # sock.bind(('0.0.0.0', sport))
 
     while True:
         data = sock.recv(1024)
         print('\rpeer: {}\n> '.format(data.decode()), end='')
 
-listener = threading.Thread(target=listen, daemon=True);
+listener = threading.Thread(target=listen, args=(sock,), daemon=True);
 listener.start()
 
 # send messages


### PR DESCRIPTION
On windows binding the two sockets to the same port, as done here wit the listener and the hole puncher socket, doesn't always work. For me it didn't work at all. My solution involves keeping the hole punching socket open and just passing it to the other peer.